### PR TITLE
fix(review): prevent flicker of not found message after delete

### DIFF
--- a/src/pages/Review.tsx
+++ b/src/pages/Review.tsx
@@ -21,7 +21,7 @@ const Review = () => {
   
   const post = posts.find((post) => post.id === Number(id));
 
-  if (!post) {
+  if (!post && !openToast) {
     return (
       <Box className="NotFound" sx={{ textAlign: 'center', mt: 5 }}>
         해당 글을 찾을 수 없습니다!😭
@@ -34,8 +34,8 @@ const Review = () => {
     setOpenToast(true);
     
     setTimeout(() => {
-      deletePost(Number(id));
       navigate('/watched');
+      deletePost(Number(id));
     }, 1500);
   };
 


### PR DESCRIPTION
## Overview
This PR fixes a UI flickering issue on the review detail page where a "not found" message briefly appeared after deleting a post. The issue was caused by a temporary state mismatch between deletion and navigation.

## Changes
- Prevented rendering of the "not found" state during the deletion process
- Adjusted conditional rendering logic using deletion state
- Improved UX by eliminating flicker before navigation to the list page

<br>