### PR TITLE
chore: add GitHub Actions workflow to prevent Supabase project pausing

### DIFF
--- a/.github/workflows/supabase-keep-alive.yml
+++ b/.github/workflows/supabase-keep-alive.yml
@@ -1,0 +1,32 @@
+name: Supabase DB keep Alive
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # KST 09:00
+  workflow_dispatch:
+
+jobs:
+  keep-alive:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+        
+      - name: Install dependencies
+        run: npm install
+      
+      - name: Run Keep Alive Script
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+        run: |
+          echo "시작 시간: $(date)"
+          node scripts/supabase-ping.mjs
+    

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,7 +9,7 @@ export default [
 
   // 무시할 폴더
   {
-    ignores: ["dist", "node_modules"],
+    ignores: ["dist", "node_modules", 'scripts/**'],
   },
 
   // TS + React 룰

--- a/scripts/supabase-ping.mjs
+++ b/scripts/supabase-ping.mjs
@@ -1,0 +1,27 @@
+/* eslint-env node (supabase ping) */
+
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  console.error("Missing Supabase environment variables.");
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+async function pingDatabase() {
+  // review 테이블에서 id 1개만 조회
+  const { data, error } = await supabase.from('reviews').select('id').limit(1);
+
+  if (error) {
+    console.error('Supabase ping failed:', error.message);
+    process.exit(1);
+  } else {
+    console.log('Supabase ping successful! Connection is alive.');
+  }
+}
+
+pingDatabase();


### PR DESCRIPTION
## Overview
This PR introduces a GitHub Actions workflow designed to prevent the Supabase project from automatically pausing due to inactivity. By leveraging a daily cron job that executes a lightweight database query, we ensure consistent repository activity and keep the Supabase database connection alive without relying on manual triggers.

## Changes
* Added Supabase Keep-Alive Workflow: 
  * Created `supabase-keep-alive.yml` to trigger a GitHub Actions schedule daily at 00:00 UTC (09:00 KST).
* Created Database Ping Script: 
  * Added a lightweight Node.js script under `scripts/supabase-ping.mjs` that performs a minimal `SELECT` query on the review table.
* Updated ESLint Configuration: 
  * Modified `eslint.config.js` to exclude the `/scripts` directory from the frontend linting scope, resolving Node.js environment variable conflicts (process is not defined).

<br>